### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,12 @@ Obviously, it decreases the panorama's quality and you'd better avoid this trans
 
 # Requirements
 
-The program requires the Intel [Threading Building Blocks](https://www.threadingbuildingblocks.org/) (TBB), [libpng](http://www.libpng.org/pub/png/libpng.html), xorg-dev, and [libjpeg](http://libjpeg.sourceforge.net/) libaries.
+The program requires the Intel [Threading Building Blocks](https://www.threadingbuildingblocks.org/) (TBB), [libpng](http://www.libpng.org/pub/png/libpng.html), and [libjpeg](http://libjpeg.sourceforge.net/) libraries.
 
 On ubuntu these can be installed with 
 ```
-sudo apt-get install libtbb-dev libpng-dev libjpeg-dev xorg-dev
+sudo apt-get install libtbb-dev libpng-dev libjpeg-dev
 ```
-
-If you see the following error message:
-```
-sh: 1: convert: not found
-sh: 1: gm: not found
-```
-Then the solution is:
-```
-sudo apt-get install imagemagick
-sudo apt-get install graphicsmagick (optional)
-````
 
 # How to build the panorama converter
 
@@ -58,7 +47,7 @@ git submodule init
 git submodule update
 ```
 
-Check other dependencies (JPG, PNG, X11, Intel TBB). Update paths in the makefile if needed.
+Check other dependencies (JPG, PNG, Intel TBB). Update paths in the makefile if needed.
 
 Make the panorama tool
 ```

--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ LFLAGS = -L/usr/X11/lib -L/usr/local/Cellar/jpeg/8d/lib -L/opt/local/lib
 # define any libraries to link into executable:
 #   if I want to link in libraries (libx.so or libx.a) I use the -llibname 
 #   option, something like (this will link in libmylib.so and libm.so:
-LIBS = -lpthread -lX11 -lpng -ljpeg -ltbb
+LIBS = -lpthread -lpng -ljpeg -ltbb
 
 #
 # The following part of the makefile is generic; it can be used to 

--- a/panorama.cpp
+++ b/panorama.cpp
@@ -5,6 +5,9 @@
 #include <unistd.h>
 
 // CImg library
+#define cimg_display 0
+#define cimg_use_jpeg
+#define cimg_use_png
 #include "CImg/CImg.h"
 using namespace cimg_library;
 
@@ -129,7 +132,6 @@ int main (int argc, char *argv[]) {
     for (int i=0; i<6; ++i){
         std::string fname = std::string(ovalue) + "_" + std::to_string(i) + ".jpg";//".jpg";
         imgOut[i]->save_jpeg( fname.c_str(), 85);
-//        imgOut[i]->save_png(fname.c_str());
     }
     
     std::cout << "  convertation finished successfully\n";


### PR DESCRIPTION
The dependencies required by CImg are configured by defining macros.

Define cimg_display=0 so that the X11 library is not required.

Define cimg_use_jpeg and cimg_use_png so that the JPEG and PNG
libraries will be used, instead of shelling out to ImageMagick. This
should fix the errors mentioned in the README.
